### PR TITLE
Use env var for admin token

### DIFF
--- a/src/main/java/org/mitre/hapifhir/BackendAuthorizationInterceptor.java
+++ b/src/main/java/org/mitre/hapifhir/BackendAuthorizationInterceptor.java
@@ -53,7 +53,8 @@ public class BackendAuthorizationInterceptor extends AuthorizationInterceptor {
       if (matcher.find() && matcher.groupCount() == 1) {
         token = matcher.group(1);
 
-        if (token.equals("admin")) {
+        String adminToken = System.getenv("ADMIN_TOKEN");
+        if (adminToken != null && token.equals(adminToken)) {
           return authorizedRule();
         } else {
           try {


### PR DESCRIPTION
Use the value of ADMIN_TOKEN as the admin token. If it is not set then do not include an admin backdoor for authorization. To test run `./gradlew publishToMavenLocal` and then run the medmorph-fhir-server locally.